### PR TITLE
Handle exception when version contains arbitrary letters

### DIFF
--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -49,7 +49,11 @@ class Version(object):
                 self.versionlist.append(i)
 
     def numpart(self,s):
-        return int(''.join(re.findall('\d',s)))
+        try:
+            return int(''.join(re.findall('\d',s)))
+        except ValueError:
+            # if numpart is '', int() can't convert it so treat as 0
+            return 0
 
     def __cmp__(self, other):
         """


### PR DESCRIPTION
If a version contains a letter, the following stack trace is generated:
`    Traceback (most recent call last):`
`  File "./pykan", line 359, in <module>`
`    actions[options.action]['method']()`
`  File "./pykan", line 165, in list_modules`
`    if modid not in result or Version(result[modid]['version']) < Version(version):`
`  File "/home/bblough/pykan/pyKAN/libPyKAN/version.py", line 102, in __lt__`
`    return self.__cmp__(other) < 0`
`  File "/home/bblough/pykan/pyKAN/libPyKAN/version.py", line 77, in __cmp__`
`    return other.__cmp__(self)`
`  File "/home/bblough/pykan/pyKAN/libPyKAN/version.py", line 91, in __cmp__`
`    if self.numpart(j) <= self.numpart(i):`
`  File "/home/bblough/pykan/pyKAN/libPyKAN/version.py", line 52, in numpart`
`    return int(''.join(re.findall('\d',s)))`
`ValueError: invalid literal for int() with base 10: ''`

Fixed by catching the exception and treating a numpart of '' as 0.  Issue can be reproduced (and fix verified) with xScience version 5.3b.