### PR TITLE
Fix "Invalid KSP directory. No version in readme.txt" bug and some spelling fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+test/
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
-test/
 
 # Translations
 *.mo

--- a/libPyKAN/pykancfg.py
+++ b/libPyKAN/pykancfg.py
@@ -38,9 +38,9 @@ class PyKANSettings(object):
                 if self.KSPSettings.get(i,None) == None:
                     util.debug('%s is not set - parsing KSP readme.txt')
                     data = open(os.path.join(KSPDIR,'readme.txt'),'rb').read()
-                    d = data
-                    for line in d.split(b'\\n'):
-                        if line.startswith(b'Version'):
+                    d = data.decode('utf-8')
+                    for line in d.split('\\n'):
+                        if line.startswith('Version'):
                             v = str(version.Version(line.split()[1]))
                             util.debug('Found value for %s: %s' %(i,v))
                             break

--- a/libPyKAN/pykancfg.py
+++ b/libPyKAN/pykancfg.py
@@ -38,7 +38,7 @@ class PyKANSettings(object):
                 if self.KSPSettings.get(i,None) == None:
                     util.debug('%s is not set - parsing KSP readme.txt')
                     data = open(os.path.join(KSPDIR,'readme.txt'),'rb').read()
-                    d = str(data)
+                    d = data
                     for line in d.split(b'\\n'):
                         if line.startswith(b'Version'):
                             v = str(version.Version(line.split()[1]))

--- a/libPyKAN/pykancfg.py
+++ b/libPyKAN/pykancfg.py
@@ -38,7 +38,7 @@ class PyKANSettings(object):
                 if self.KSPSettings.get(i,None) == None:
                     util.debug('%s is not set - parsing KSP readme.txt' %i)
                     data = open(os.path.join(KSPDIR,'readme.txt'),'rb').read()
-                    d = data.decode('utf-8')
+                    d = str(data)
                     for line in d.split('\\n'):
                         if line.startswith('Version'):
                             v = str(version.Version(line.split()[1]))

--- a/libPyKAN/pykancfg.py
+++ b/libPyKAN/pykancfg.py
@@ -1,6 +1,6 @@
 #Manages and provides access to the pykan specific settings files.
 #To files are kept. One in $HOME/.pykan.json which stores the paths to
-#all registered KSP installs. One in each KSPDIR/PYKAN/pykan_settings.json 
+#all registered KSP installs. One in each KSPDIR/PYKAN/pykan_settings.json
 #which stores all other settings specific to each install.
 
 import json
@@ -31,7 +31,7 @@ class PyKANSettings(object):
             util.debug('Found KSP directory')
             self.KSPSettingsFile = os.path.join(KSPDIR,'PYKAN','pykan_settings.json')
             util.mkdir_p(os.path.dirname(self.KSPSettingsFile))
-            self.KSPSettings=util.ReadJsonFromFile(self.KSPSettingsFile,self.KSPSettings,create=True)            
+            self.KSPSettings=util.ReadJsonFromFile(self.KSPSettingsFile,self.KSPSettings,create=True)
             for i in ['minKSPversion','maxKSPversion']:
                 util.debug('Checking %s: %s' % (i,self.KSPSettings.get(i,None)))
                 v = None
@@ -39,8 +39,8 @@ class PyKANSettings(object):
                     util.debug('%s is not set - parsing KSP readme.txt')
                     data = open(os.path.join(KSPDIR,'readme.txt'),'rb').read()
                     d = str(data)
-                    for line in d.split('\\n'):
-                        if line.startswith('Version'):
+                    for line in d.split(b'\\n'):
+                        if line.startswith(b'Version'):
                             v = str(version.Version(line.split()[1]))
                             util.debug('Found value for %s: %s' %(i,v))
                             break
@@ -136,16 +136,3 @@ class PyKANSettings(object):
 
     def __len__(self):
         return len(list(self.SharedSettings.keys())) + len(list(self.KSPSettings.keys()))
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/libPyKAN/pykancfg.py
+++ b/libPyKAN/pykancfg.py
@@ -36,7 +36,7 @@ class PyKANSettings(object):
                 util.debug('Checking %s: %s' % (i,self.KSPSettings.get(i,None)))
                 v = None
                 if self.KSPSettings.get(i,None) == None:
-                    util.debug('%s is not set - parsing KSP readme.txt')
+                    util.debug('%s is not set - parsing KSP readme.txt' %i)
                     data = open(os.path.join(KSPDIR,'readme.txt'),'rb').read()
                     d = data.decode('utf-8')
                     for line in d.split('\\n'):

--- a/libPyKAN/util.py
+++ b/libPyKAN/util.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     raise ImportError("This program requires the python3 requests module. Please install it using pip or your distro's package manager")
 
-DEBUG=False
+DEBUG = False
 default_ckan_repo = "https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz"
 repository_list = "https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json"
 
@@ -30,7 +30,7 @@ def shacheck(filename, sha, failonmissing=True):
         text = open(filename,'rb').read()
         if len(sha) == 40:
             hashobj = hashlib.sha1(text)
-        else: 
+        else:
             hashobj = hashlib.sha256(text)
         if hashobj.hexdigest().upper() !=sha.upper():
             print('Error in sha verification "%s" != "%s"' %(hashobj.hexdigest().upper(), sha.upper()))
@@ -53,7 +53,7 @@ def __download_file__(dl_data):
         try:
             r = requests.get(dl_data['uri'], stream=True)
             with open(filename, 'wb') as f:
-                for chunk in r.iter_content(chunk_size=1024): 
+                for chunk in r.iter_content(chunk_size=1024):
                     if chunk:
                         sys.stdout.write('#')
                         sys.stdout.flush()
@@ -67,7 +67,7 @@ def __download_file__(dl_data):
         except Exception as e:
             retries += 1
             if retries >=  dl_data['retries']:
-                raise           
+                raise
             debug ('Download error %s. %s  retries remain' %(e, dl_data['retries'] - retries))
             done = False
     print()
@@ -102,7 +102,7 @@ def debug_n(message):
         sys.stderr.flush()
 
 def SaveJsonToFile(filename,data):
-    open(filename,'w').write(json.dumps(data,indent=4))    
+    open(filename,'w').write(json.dumps(data,indent=4))
 
 def ReadJsonFromFile(filename, default=None,create=False):
     if default == None:
@@ -122,5 +122,3 @@ def mkdir_p(targetpath):
         if e.errno != errno.EEXIST:
             raise
     return
-
-

--- a/pyKAN
+++ b/pyKAN
@@ -35,8 +35,8 @@ def select_menu(msg, options):
     return answer
 
 def confirm(msg='Continue [y/n]'):
-        answer = input("Continue [y/n]")
-        return answer.lower().startswith('y')
+    answer = input("Continue [y/n]")
+    return answer.lower().startswith('y')
 
 
 

--- a/pyKAN
+++ b/pyKAN
@@ -142,7 +142,7 @@ if __name__ == '__main__':
             return
         if options.installed:
             for i in sorted(INSTALLED.list_modules(), key=lambda k: k['identifier']):
-                print('%s :  %s | %s (%s)' %(i['identifier'],i['name'],i['version'],i['status']))
+                print('%s :  %s | %s (%s)' %(i['identifier'], i['name'], i['version'], i['status']))
             return
         if options.allmods:
             filtermethods = []
@@ -166,7 +166,7 @@ if __name__ == '__main__':
                     result[modid] = {'name': name, 'version': version}
         if result:
             for i in sorted(result):
-                print("%s :  %s | %s (%s)" %(i,result[i]['name'],result[i]['version'],INSTALLED.modstatus(i)))
+                print("%s :  %s | %s (%s)" %(i,result[i]['name'], result[i]['version'], INSTALLED.modstatus(i)))
 
 
     def show_module():
@@ -320,7 +320,7 @@ if __name__ == '__main__':
     parser.add_argument('--module',type=str,default=None,help='Name of the module. Use with show,install, uninstall and upgrade.')
     parser.add_argument('--version',type=str,default=None,help='Version of the module. Use with install. Optional: default to latest compatible version.')
     parser.add_argument('--recommends',type=str,default='ask',choices=['ask','yes','no'],help='What to do with recommended mods. Default: ask.')
-    parser.add_argument('--suggests',type=str,default='no',choices=['ask','yes','no'],help='What to do with sugested mods. Default: no (do not install).')
+    parser.add_argument('--suggests',type=str,default='no',choices=['ask','yes','no'],help='What to do with suggested mods. Default: no (do not install).')
 
     parser.epilog = 'Actions:\n'
     for i in sorted(actions.keys()):


### PR DESCRIPTION
Before:
```
feanor@silmaril ~/D/P/pyKAN> ./pyKAN --kspdir test update --debug
KSP Directory: test
Found KSP directory
Checking minKSPversion: None
%s is not set - parsing KSP readme.txt
Invalid KSP directory. No version in readme.txt !
```

After:
```
feanor@silmaril ~/D/P/pyKAN> ./pyKAN --kspdir test update --debug
KSP Directory: test
Found KSP directory
Checking minKSPversion: None
%s is not set - parsing KSP readme.txt
Found value for minKSPversion: 1.0.0
Setting minKSPversion to 1.0.0
Checking maxKSPversion: None
%s is not set - parsing KSP readme.txt
Found value for maxKSPversion: 1.0.0
Setting maxKSPversion to 1.0.0
Settings object initated: {
    "KSPDIRS": [],
    "DownLoadRetryMax": 1,
    "Repos": [
        "https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz"
    ],
    "minKSPversion": "1.0.0",
    "maxKSPversion": "1.0.0"
}
Downloading updated repositories
Downloading https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json

```

Both of these were tested using test KSP folder provided in the source. It turns out that pyKANSettings class ` __init__ ` function reads the KSP readme.txt as read binary (rb), which returns a byte str,  attempts to convert it into string by using `d = str(data)`, which **does not** convert it into Python strings as we might expect, because the proper way to convert binary into string is to use `decode` function. As subsequent comparisons tries to compare d with a string Version, it will be never equal, which results to "Invalid KSP directory. No version in readme.txt !" error. By replacing the `str(data)` function with `data.decode('utf-8')` it works as expected