### PR TITLE
Small merge fix

### DIFF
--- a/pyKAN
+++ b/pyKAN
@@ -401,4 +401,4 @@ if __name__ == '__main__':
         settings.reload()
         print("Using KSP Directory: ",settings.KSPDIR)
 
-    actions[options.action]['method']()
+    options.func(options)


### PR DESCRIPTION
I think that the conflict merge results with git picking `actions[options.action]['method']()` instead of `options.func(options)`, which makes the program crash as there is no `actions` variable anymore