### PR TITLE
Fix JSON dump when a dependency is not found

### DIFF
--- a/libPyKAN/modmanager.py
+++ b/libPyKAN/modmanager.py
@@ -228,7 +228,7 @@ class ModManager(object):
                                 continue
                             found =  self.repo.find_latest(m['name'])
                             if not found and key is  'depends': #Failing to find a suggestion is not a crisis
-                                raise MissingDependencyException('Could not find module %s required by %s' %(m['name'],mod))
+                                raise MissingDependencyException('Could not find module %s required by %s' %(m['name'],mod['identifier']))
                             if len(found) > 1:
                                 fnd = [i for i in found if i in dl_list or i in self.installed.all_modnames()]
                                 if not fnd:


### PR DESCRIPTION
Before: 
```
feanor@silmaril ~/D/P/pyKAN> ./pyKAN --kspdir 1 install KSPInterstellarExtended
Using KSP Directory:  /home/feanor/.local/share/Steam/steamapps/common/Kerbal Space Program

Could not find module CommunityTechTree required by {'spec_version': 'v1.4', 'comment': 'return vref when .version file is valid', 'identifier': 'KSPInterstellarExtended', 'name': 'KSP Interstellar Extended', 'abstract': 'KSP Interstellar Extended (KSPI-E) is a plugin for Kerbal Space Program, designed to encourage bootstrapping toward ever more advanced levels of technology as well as utilizing In-Situ resources to expand the reach of Kerbal civilization. KSP Interstellar Extended aims to continue in Fractals original KSPI vision in providing a realistic road to the stars. Note: requires CTT 3.0.1', 'author': 'FreeThinker', 'license': 'GPL-3.0', 'resources': {'homepage': 'http://forum.kerbalspaceprogram.com/index.php?/topic/100190-113/&page=1', 'spacedock': 'https://spacedock.info/mod/172/KSP%20Interstellar%20Extended', 'repository': 'https://github.com/sswelm/KSP-Interstellar-Extended', 'x_screenshot': 'https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png'}, 'version': '1.14.1', 'ksp_version': '1.3.0', 'depends': [{'name': 'CommunityResourcePack', 'min_version': '0.6.5'}, {'name': 'InterstellarFuelSwitch-Core', 'min_version': '2.6.0'}, {'name': 'TweakScale', 'min_version': '2.3.3'}, {'name': 'ModuleManager', 'min_version': '2.7.5'}, {'name': 'CommunityTechTree', 'min_version': '1:3.0.3'}, {'name': 'UniversalStorage', 'min_version': '1.2.2'}], 'recommends': [{'name': 'InterstellarFuelSwitch'}, {'name': 'FilterExtensions'}, {'name': 'KSP-AVC'}, {'name': 'HideEmptyTechNodes'}, {'name': 'KerbalJointReinforcement'}, {'name': 'UniversalStorage'}, {'name': 'PersistentRotation'}], 'install': [{'find': 'GameData/WarpPlugin', 'install_to': 'GameData'}], 'download': 'https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.14.1', 'download_size': 114729354, 'download_hash': {'sha1': '920618140376B414338FF61EDC43319D2C41D816', 'sha256': '81883E4BA4FD9DC94BD0E48CF93935168ABEFF1FA7726C19386876D6D1780286'}, 'download_content_type': 'application/zip', 'x_generated_by': 'netkan'}
```

After:
```
feanor@silmaril ~/D/P/pyKAN> ./pyKAN --kspdir 1 install KSPInterstellarExtended
Using KSP Directory:  /home/feanor/.local/share/Steam/steamapps/common/Kerbal Space Program

Could not find module CommunityTechTree required by KSPInterstellarExtended
```