### PR TITLE
Implement ksp_version_strict for CKAN spec v1.16

### DIFF
--- a/libPyKAN/filters.py
+++ b/libPyKAN/filters.py
@@ -29,16 +29,17 @@ class Filter(object):
         False
         """
         modversion = repoentry.get('ksp_version',None)
+        strictness = repoentry.get('ksp_version_strict',False)#CKAN spec v1.16 assumes that KSP version 1.3.1 == 1.3 if ksp_version_strict is not in the metadata
         if modversion:
             return modversion == 'any' or Version(modversion) >= Version(self.settings.KSPSettings['minKSPversion']) and Version(modversion) <= Version(self.settings.KSPSettings['maxKSPversion'])
         minversion = repoentry.get('ksp_version_min',None)
         maxversion = repoentry.get('ksp_version_max',None)
         if minversion and not maxversion:
-            return  Version(self.settings.KSPSettings['maxKSPversion']) >= Version(minversion)
+            return  Version(strictness,self.settings.KSPSettings['maxKSPversion']) >= Version(minversion)
         if maxversion and not minversion:
-            return Version(self.settings.KSPSettings['minKSPversion']) <= Version(maxversion)
+            return Version(strictness,self.settings.KSPSettings['minKSPversion']) <= Version(maxversion)
         if minversion and maxversion:
-            return Version(self.settings.KSPSettings['maxKSPversion']) >= Version(minversion) and Version(self.settings.KSPSettings['minKSPversion']) <= Version(maxversion)
+            return Version(strictness,self.settings.KSPSettings['maxKSPversion']) >= Version(minversion) and Version(strictness,self.settings.KSPSettings['minKSPversion']) <= Version(maxversion)
 
         #If we can't figure out compatibility - we assume yes. My first thought would be no but apparently CKAN assumes yes - which forces us to follow suit
         return True

--- a/libPyKAN/util.py
+++ b/libPyKAN/util.py
@@ -35,7 +35,7 @@ def shacheck(filename, sha, failonmissing=True):
         else:
             hashobj = hashlib.sha256(text)
         if hashobj.hexdigest().upper() !=sha.upper():
-            print('Error in sha verification "%s" != "%s"' %(hashobj.hexdigest().upper(), sha.upper()))
+            print('Error in sha verification of %s "%s" != "%s"' %(filename, hashobj.hexdigest().upper(), sha.upper()))
             return False
     return True
 

--- a/libPyKAN/util.py
+++ b/libPyKAN/util.py
@@ -12,6 +12,8 @@ except ImportError:
     raise ImportError("This program requires the python3 requests module. Please install it using pip or your distro's package manager")
 
 DEBUG = False
+NOBAR = False
+
 default_ckan_repo = "https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz"
 repository_list = "https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json"
 
@@ -55,7 +57,8 @@ def __download_file__(dl_data):
             with open(filename, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     if chunk:
-                        sys.stdout.write('#')
+                        if not NOBAR:
+                            sys.stdout.write('#')
                         sys.stdout.flush()
                         f.write(chunk)
                 done = True

--- a/libPyKAN/util.py
+++ b/libPyKAN/util.py
@@ -63,7 +63,7 @@ def __download_file__(dl_data):
                         f.write(chunk)
                 done = True
             if r.status_code != 200:
-                raise IOError("Download failed %s" %r.status_code)
+                raise IOError("Download failed for %s: %s" %(dl_data['uri'],r.status_code))
             if shacheck(filename,dl_data['sha'], False):
                 print()
                 debug("Warning: Sha hash for %s does not match repo data" % filename)

--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -5,7 +5,7 @@ from functools import total_ordering
 
 @total_ordering
 class Version(object):
-    def __init__(self,*args):
+    def __init__(self,*args,strict=True):
         """
         >>> Version('0.0.1').versionlist
         ['0', '0', '1']
@@ -17,6 +17,7 @@ class Version(object):
         ['0', '0', '4']
 
         """
+        self.strict = strict
         versionlist = []
         if len(args) == 1 and isinstance(args[0],str):
             vstring = args[0]
@@ -75,6 +76,10 @@ class Version(object):
         if self.versionlist == other.versionlist:
             #if the contents are identical it's a definite match
             return 0
+        if not self.strict:
+            #CKAN spec v1.16 ksp_version_strict compliance
+            if self.versionlist[:-1] == other.versionlist[:-1]:
+                return 0
         if str(self) == 'any' or str(other) == 'any':
             return 0
         if len(other.versionlist) > len(self.versionlist):

--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -1,11 +1,11 @@
 #Generic datatype for version information
-import util
+from . import util
 import re
 from functools import total_ordering
 
 @total_ordering
 class Version(object):
-    def __init__(self,*args,strict=True):
+    def __init__(self,strict=True,*args):
         """
         >>> Version('0.0.1').versionlist
         ['0', '0', '1']
@@ -72,10 +72,12 @@ class Version(object):
         True
         >>> Version('0.4.3') < Version('0.14.3')
         True
-        >>> Version('0.4.3', strict=True) != Version('0.4')
+        >>> Version(strict=True, '0.4.3') != Version('0.4')
         True
-        >>> Version('0.4.3', strict=False) == Version('0.4')
+        >>> Version(strict=False, '0.4.3') == Version('0.4')
         True
+        >>> Version('0.4.3') == Version('0.4')
+        False
         """
         if not isinstance(other,Version):
             other=Version(other)
@@ -107,7 +109,7 @@ class Version(object):
                     return 1
                 else:
                     return -1
-            if int(i) > int(j): #Use integer comparison to ensure that 14 > 4 
+            if int(i) > int(j): #Use integer comparison to ensure that 14 > 4
                 return 1
             if int(i) < int(j):
                 return -1

--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -70,6 +70,12 @@ class Version(object):
         True
         >>> Version(0,0,5,1) > Version(0,0,5)
         True
+        >>> Version('0.4.3') < Version('0.14.3')
+        True
+        >>> Version('0.4.3', strict=True) != Version('0.4')
+        True
+        >>> Version('0.4.3', strict=False) == Version('0.4')
+        True
         """
         if not isinstance(other,Version):
             other=Version(other)
@@ -78,7 +84,7 @@ class Version(object):
             return 0
         if not self.strict:
             #CKAN spec v1.16 ksp_version_strict compliance
-            if self.versionlist[:-1] == other.versionlist[:-1]:
+            if self.versionlist[:-1] == other.versionlist:
                 return 0
         if str(self) == 'any' or str(other) == 'any':
             return 0

--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -40,13 +40,13 @@ class Version(object):
         for i in versionlist:
                 #We need a common type for everything to get consistent comparisons
                 #Strings are the most universal and numeric ones compare fairly well.
-                i = str(i)
-                #But extra leading zeroes screw things up
-                while i.startswith('0') and len(i) > 1:
-                    i = i[1:]
-                if i == '.':
-                    continue
-                self.versionlist.append(i)
+            i = str(i)
+            #But extra leading zeroes screw things up
+            while i.startswith('0') and len(i) > 1:
+                i = i[1:]
+            if i == '.':
+                continue
+            self.versionlist.append(i)
 
     def numpart(self,s):
         try:

--- a/libPyKAN/version.py
+++ b/libPyKAN/version.py
@@ -1,5 +1,5 @@
 #Generic datatype for version information
-from . import util
+import util
 import re
 from functools import total_ordering
 
@@ -107,9 +107,9 @@ class Version(object):
                     return 1
                 else:
                     return -1
-            if i > j:
+            if int(i) > int(j): #Use integer comparison to ensure that 14 > 4 
                 return 1
-            if i < j:
+            if int(i) < int(j):
                 return -1
         return 0
 

--- a/pyKAN
+++ b/pyKAN
@@ -307,6 +307,7 @@ if __name__ == '__main__':
     parser.add_argument('--version',type=str,default=None,help='Version of the module. Use with install. Optional: default to latest compatible version.')
     parser.add_argument('--recommends',type=str,default='ask',choices=['ask','yes','no'],help='What to do with recommended mods. Default: ask.')
     parser.add_argument('--suggests',type=str,default='no',choices=['ask','yes','no'],help='What to do with suggested mods. Default: no (do not install).')
+    parser.add_argument('--nobar',action='store_true',help='Disables download progress bar')
 
 
     #Positional sub arguments
@@ -378,6 +379,7 @@ if __name__ == '__main__':
 
     options = parser.parse_args(sys.argv[1:])
     util.DEBUG=options.debug
+    util.NOBAR = options.nobar
     if isinstance(options.kspdir, str) and not options.kspdir.isdigit():
         kspdir = options.kspdir
     else:


### PR DESCRIPTION
Some mods such as MechJeb specify their `ksp_version` as 1.3 instead of 1.3.0, and with pyKAN strict by default version comparison, 1.3 != 1.3.0, making MechJeb fails to download. As of CKAN spec v1.16, if the mod does not specify ksp_version_strict, 1.3 == 1.3.0, or even 1.3 = 1.3.1