### PR TITLE
Fix fragile comparison in find_latest

### DIFF
--- a/libPyKAN/ckanRepo.py
+++ b/libPyKAN/ckanRepo.py
@@ -52,7 +52,7 @@ class CkanRepo(object):
         result = {}
         for i in self.list_modules(filters,filterargs):
             if (i['identifier'] == identifier or i['name'] == identifier or identifier in i.get('provides',[])):
-                if  i['identifier'] not in result or i['version'] >= result[i['identifier']]['version']:
+                if  i['identifier'] not in result or Version(i['version']) >= Version(result[i['identifier']]['version']):
                     result[i['identifier']] = i
         return result
 


### PR DESCRIPTION
This happen again: https://github.com/KSP-CKAN/NetKAN/issues/5635#issuecomment-309202664 and it turns out that pyKAN find_latest is using string comparison to determine latest version instead of Version _cmp_ method that is specifically designed to prevent 1.6.0 > 1.16.1 