### PR TITLE
Fix missing argument in delkspdir

### DIFF
--- a/pyKAN
+++ b/pyKAN
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         settings.addkspdir(kspdir)
         listkspdirs('_')
 
-    def delkspdir():
+    def delkspdir(_):
         if not options.kspdir:
             util.error('You must specify --kspdir when removing a KSP directory')
         settings.delkspdir(kspdir)


### PR DESCRIPTION
I couldn't get the `delkspdir` command to work, seems an underscore was missing in the function declaration. 