### PR TITLE
Show usage when running pyKAN with no arguments

### DIFF
--- a/pyKAN
+++ b/pyKAN
@@ -398,4 +398,8 @@ if __name__ == '__main__':
         settings.reload()
         print("Using KSP Directory: ",settings.KSPDIR)
 
-    options.func(options)
+    if hasattr(options, 'func'):
+        options.func(options)
+    else:
+        parser.print_usage()
+


### PR DESCRIPTION
Running pyKAN with no arguments causes an AttributeError exception.  Show "usage" instead.
