### PR TITLE
Change install/uninstall to be case insensitive

### DIFF
--- a/libPyKAN/ckanRepo.py
+++ b/libPyKAN/ckanRepo.py
@@ -51,14 +51,16 @@ class CkanRepo(object):
             filters = [Filter(self.settings).compatible]
         result = {}
         for i in self.list_modules(filters,filterargs):
-            if (i['identifier'] == identifier or i['name'] == identifier or identifier in i.get('provides',[])):
+            if (i['identifier'].lower() == identifier.lower() or
+                i['name'].lower() == identifier.lower() or
+                identifier.lower() in ( x.lower() for x in i.get('provides',[]))):
                 if  i['identifier'] not in result or Version(i['version']) >= Version(result[i['identifier']]['version']):
                     result[i['identifier']] = i
         return result
 
     def find_version(self, identifier, version):
         for i in self.repodata:
-            if (self.repodata[i]['identifier'] == identifier or self.repodata[i]['name'] == identifier) and Version(self.repodata[i]['version']) == Version(version):
+            if (self.repodata[i]['identifier'].lower() == identifier.lower() or self.repodata[i]['name'].lower() == identifier.lower()) and Version(self.repodata[i]['version']) == Version(version):
                 return self.repodata[i]
         return None
 

--- a/pyKAN
+++ b/pyKAN
@@ -241,9 +241,11 @@ if __name__ == '__main__':
         if not options.module:
             util.error('Must specify --module with uninstall')
         for mod_opt in options.module:
-            if not mod_opt in INSTALLED.all_modnames():
+            try:
+                modid = next((x for x in INSTALLED.all_modnames() if x.lower() == mod_opt.lower()))
+            except:
                 util.error('Cannot uninstall %s as it is not installed' %mod_opt)
-            mod += [INSTALLED[mod_opt]]
+            mod += [INSTALLED[modid]]
         MM = ModManager(mod, settings,repo)
         remlist = MM.uninstall_list()
         print("About to remove: \n\t%s" %('\n\t'.join(remlist)))


### PR DESCRIPTION
Searching modules is already case insensitive, however when trying to
install or uninstall modules it requires the case entered to be exactly as
it shows in the module list.

Per the CKAN spec ( https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md ),
identifiers "must be both: case sensitive for machines, and unique regardless
of capitalization for human consumption and case-ignorant systems."

Switching to case insensitive matching for install/uninstall will improve
usability, and the spec ensures that doing so will not cause issues
with name collisions.